### PR TITLE
Add (temp) LookupName for checking server >= 5.4.8

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -120,6 +120,12 @@ public class LookupNames
     /** Field to access the <code>Version</code> information. */
     public static final String VERSION = "Version";
 
+    /** 
+     * Field to check if the server version is 5.4.8 or later.
+     * TODO: Can be removed for >= 5.5.0 release
+     * */
+    public static final String SERVER_5_4_8_OR_LATER = "5.4.8 or later";
+    
     /** Field to access the <code>Name of the software</code>. */
     public static final String SOFTWARE_NAME = "SoftwareName";
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -67,6 +67,7 @@ import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.svc.proxy.ProxyUtil;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.openmicroscopy.shoola.util.VersionCompare;
 import org.openmicroscopy.shoola.util.ui.IconManager;
 import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.NotificationDialog;
@@ -585,6 +586,9 @@ public class DataServicesFactory
         	omeroGateway.logout();
         	return;
         }
+
+        // TODO: Can be removed for >= 5.5.0 release
+        container.getRegistry().bind(LookupNames.SERVER_5_4_8_OR_LATER, VersionCompare.compare(version, "5.4.8") >= 0);
 
         //Upgrade check only if client and server are compatible
         omeroGateway.isUpgradeRequired(name);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -33,11 +33,12 @@ import omero.gateway.model.DataObject;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.PixelsData;
 import omero.log.LogMessage;
+
+import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.OmeroImageService;
 import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
 import org.openmicroscopy.shoola.env.data.views.BatchCall;
 import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
-import org.openmicroscopy.shoola.util.VersionCompare;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
 import org.openmicroscopy.shoola.util.image.io.WriterImage;
 
@@ -68,11 +69,6 @@ import java.util.HashSet;
  * @since OME2.2
  */
 public class ThumbnailLoader extends BatchCallTree {
-
-    /**
-     * Version of OMERO.server with {@code getThumbnailWithoutDefault}
-     */
-    private static final String VERSION_THUMBNAIL_NO_DEFAULT = "5.4.8";
 
     /**
      * The images for which we need thumbnails.
@@ -333,9 +329,10 @@ public class ThumbnailLoader extends BatchCallTree {
                 store.setRenderingDefId(rndDefId);
         }
 
-        if (VersionCompare.compare(context.getGateway().getServerVersion(), VERSION_THUMBNAIL_NO_DEFAULT) >= 0) {
+        if ((boolean) context.lookup(LookupNames.SERVER_5_4_8_OR_LATER)) {
             // If the client is connecting to a server with version 5.4.8 or greater, use the thumbnail
             // loading function that doesn't return a clock.
+            // TODO: Can be removed for >= 5.5.0 release
             return store.getThumbnailWithoutDefault(omero.rtypes.rint(sizeX),
                     omero.rtypes.rint(sizeY));
         } else {


### PR DESCRIPTION
This would add  a`SERVER_5_4_8_OR_LATER` LookupName which is set on login and can be used later to check if the server version is >= 5.4.8. I think that's kind of the "Insight" way. It's temporary anyway, have to remember to remove it again for 5.5.x releases.
